### PR TITLE
New benchmark: case statement

### DIFF
--- a/lib/hash_vs_patterns.ex
+++ b/lib/hash_vs_patterns.ex
@@ -11,7 +11,8 @@ defmodule HashVsPatterns do
         "With patterns" => benchmark_runner(WithPatterns),
         "With hash" => benchmark_runner(WithHash),
         "With hash and patterns" => benchmark_runner(WithHashAndPatterns),
-        "With patterns and macros" => benchmark_runner(WithPatternsAndMacros)
+        "With patterns and macros" => benchmark_runner(WithPatternsAndMacros),
+        "With case" => benchmark_runner(WithCase)
       },
       print: [fast_warning: false]
     )

--- a/lib/with_case.ex
+++ b/lib/with_case.ex
@@ -1,0 +1,23 @@
+defmodule WithCase do
+  @type planet :: :mercury | :venus | :earth | :mars | :jupiter | :saturn | :uranus | :neptune
+
+  @earth_year 31_557_600
+
+  @doc """
+  Return the number of years a person that has lived for 'seconds' seconds is
+  aged on 'planet'.
+  """
+  @spec age_on(planet, pos_integer) :: float
+  def age_on(planet, seconds) do
+    seconds / @earth_year / case planet do
+      :earth -> 1
+      :mercury -> 0.2408467
+      :venus -> 0.61519726
+      :mars -> 1.8808158
+      :jupiter -> 11.862615
+      :saturn -> 29.447498
+      :uranus -> 84.016846
+      :neptune -> 164.79132
+    end
+  end
+end


### PR DESCRIPTION
Thought I'd share some results as well! :)

Just checked out this experiment and wondered how a **case statement** would fare against the other alternatives as well. It also has the advantage of not going through the `Access` protocol but it seems to have an ever so slight overhead (in my tests it ranged from 1.05x to 1.10x slower) when compared to raw pattern matching - I haven't come to a conclusion on what is the exact cause for this, however.

Here are the results for one of my runs:

```
$ mix run -e HashVsPatterns.benchmark
Operating System: Linux"
CPU Information: Intel(R) Core(TM) i5-4300M CPU @ 2.60GHz
Number of Available Cores: 4
Available memory: 7.67 GB
Elixir 1.6.5
Erlang 20.3.8

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 μs
parallel: 1
inputs: none specified
Estimated total run time: 35 s


Benchmarking With case...
Benchmarking With hash...
Benchmarking With hash and patterns...
Benchmarking With patterns...
Benchmarking With patterns and macros...

Name                               ips        average  deviation         median         99th %
With patterns                   1.75 M        0.57 μs   ±491.73%        0.50 μs           1 μs
With patterns and macros        1.74 M        0.57 μs   ±472.17%        0.50 μs           1 μs
With hash and patterns          1.73 M        0.58 μs   ±458.86%        0.50 μs           1 μs
With case                       1.64 M        0.61 μs   ±449.32%        0.50 μs        1.40 μs
With hash                       1.30 M        0.77 μs   ±388.65%        0.70 μs        1.60 μs

Comparison: 
With patterns                   1.75 M
With patterns and macros        1.74 M - 1.01x slower
With hash and patterns          1.73 M - 1.01x slower
With case                       1.64 M - 1.07x slower
With hash                       1.30 M - 1.35x slower
```